### PR TITLE
Update deprecations

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -1,6 +1,8 @@
 resource "aws_route53_zone" "main" {
     name = "${var.dns_name}"
-    vpc_id = "${aws_vpc.main.id}"
+    vpc {
+        vpc_id = "${aws_vpc.main.id}"
+    }
     comment = "${var.app}/${var.env} internal dns zone"
     tags {
         Name = "${var.app}/${var.env} internal dns"

--- a/endpoints.tf
+++ b/endpoints.tf
@@ -1,6 +1,4 @@
-data "aws_region" "current" {
-    current = true
-}
+data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "s3" {
     vpc_id = "${aws_vpc.main.id}"


### PR DESCRIPTION
using the module in shift gave these errors: 
`Error: module.vpc.aws_route53_zone.main: "vpc_id": [REMOVED] use 'vpc' configuration block instead`

`Error: module.vpc.data.aws_region.current: "current": [REMOVED] Defaults to current provider region if no other filtering is enabled`

route 53 docs for reference: https://www.terraform.io/docs/providers/aws/r/route53_zone.html